### PR TITLE
Add noise waveform option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cppSynth
 
-This is a hobby project to learn more about C++, it's a synth that can output sine, square, sawtooth and triangle.
+This is a hobby project to learn more about C++, it's a synth that can output sine, square, sawtooth, triangle and noise.
 
 You select the waveform from the dropdown box, Up arrow and down arrow change the octaves. A-; on the keyboard for the notes.
 It uses the MIDI standard.

--- a/src/GUI.cpp
+++ b/src/GUI.cpp
@@ -44,7 +44,7 @@ void GUI::Render()
         ImGui::Begin("SynthWave Oscillator");
 
         ImGui::Text("Select the waveform");
-        const char* items[] = { "sine", "square", "sawtooth", "triangle" };
+        const char* items[] = { "sine", "square", "sawtooth", "triangle", "noise" };
         if(ImGui::Combo("waveform", &currentItem, items, IM_ARRAYSIZE(items))) {
             std::lock_guard<std::mutex> lock(waveformMutex);
             waveformName = items[currentItem];

--- a/src/Oscillator.cpp
+++ b/src/Oscillator.cpp
@@ -4,6 +4,7 @@
 #include <stdexcept>
 #include <iostream>
 #include <algorithm>
+#include <random>
 
 // Define maximum number of harmonics for waveforms
 #define MAX_HARMONICS 500
@@ -17,6 +18,7 @@ Oscillator::Oscillator(unsigned tableSize, double sampleRate)
     squareWaveTable.resize(tableSize);
     sawtoothWaveTable.resize(tableSize);
     triangleWaveTable.resize(tableSize);
+    noiseWaveTable.resize(tableSize);
     silentWaveTable.resize(tableSize, 0.0); // Silent wave is just zeros
 
     frequency = 440.0;  // Set the default frequency 
@@ -26,6 +28,7 @@ Oscillator::Oscillator(unsigned tableSize, double sampleRate)
     updateSquareWaveTable();
     updateSawtoothWaveTable();
     updateTriangleWaveTable();
+    updateNoiseWaveTable();
 
     activeWaveTable = &sineWaveTable;  // Default wave form is sine
     currentPosition = 0.0;  // Reset current position
@@ -57,6 +60,16 @@ void Oscillator::updateTriangleWaveTable() {
     }
 }
 
+// Function to generate white noise values
+void Oscillator::updateNoiseWaveTable() {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_real_distribution<double> dist(-1.0, 1.0);
+    for (double &sample : noiseWaveTable) {
+        sample = dist(gen);
+    }
+}
+
 // Function to set the waveform type
 void Oscillator::setWaveform(const std::string& waveform) {
     // Switch the active waveform based on input string
@@ -71,6 +84,9 @@ void Oscillator::setWaveform(const std::string& waveform) {
     }
     else if (waveform == "triangle") {
         activeWaveTable = &triangleWaveTable;
+    }
+    else if (waveform == "noise") {
+        activeWaveTable = &noiseWaveTable;
     }
     else if (waveform == "none") {
         activeWaveTable = &silentWaveTable;

--- a/src/Oscillator.h
+++ b/src/Oscillator.h
@@ -22,6 +22,7 @@ private:
     void updateSquareWaveTable();
     void updateSawtoothWaveTable();
     void updateTriangleWaveTable();
+    void updateNoiseWaveTable();
 
     double noteToFrequency(int note);
 
@@ -32,6 +33,7 @@ private:
     std::vector<double> squareWaveTable;
     std::vector<double> sawtoothWaveTable;
     std::vector<double> triangleWaveTable;
+    std::vector<double> noiseWaveTable;
     std::vector<double> silentWaveTable;
 
     std::vector<double>* activeWaveTable;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -159,7 +159,7 @@ int main()
             ImGui::Begin("SynthWave Oscillator");
 
             ImGui::Text("Select the waveform");
-            const char* items[] = { "sine", "square", "sawtooth", "triangle" };
+            const char* items[] = { "sine", "square", "sawtooth", "triangle", "noise" };
             static int currentItem = 0;
             if(ImGui::Combo("waveform", &currentItem, items, IM_ARRAYSIZE(items))) {
                 std::lock_guard<std::mutex> lock(waveformMutex);


### PR DESCRIPTION
## Summary
- add noise wave table with random samples
- expose new noise waveform in GUI combo boxes
- update README to mention noise option

## Testing
- `bash make.sh` *(fails: imgui.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688e49e7ba70832c9fc82f2069ba3ed0