### PR TITLE
Add polyphonic playback and loop controls window

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a hobby project to learn more about C++, it's a synth that can output si
 You select the waveform from the dropdown box, Up arrow and down arrow change the octaves. A-; on the keyboard for the notes.
 It uses the MIDI standard.
 
-The UI now also provides basic recording controls. You can record your playing, play it back, and enable looping for continuous playback.
+The UI now provides separate loop controls. You can record your playing, set the tempo and number of beats for the loop, play it back, and enable looping for continuous playback. The synth is now polyphonic so multiple keys may be held at once.
 
 ## Clone
 
@@ -40,4 +40,3 @@ sudo pacman -Syu libxinerama libxcursor libxi libxrandr
 # TODO
 
 * Add visual boxes for viewing the waveforms.
-* Add more voices, right now it's mono.

--- a/src/Keyboard.h
+++ b/src/Keyboard.h
@@ -6,9 +6,20 @@
 #include "Oscillator.h"
 #include <GLFW/glfw3.h>
 #include <atomic>
+#include <vector>
+#include <mutex>
+#include <string>
+
+// Simple container for a single playing voice
+struct Voice {
+    Oscillator osc;
+    int note;
+    Voice(unsigned tableSize, double sampleRate) : osc(tableSize, sampleRate), note(0) {}
+};
 
 // Function for handling keyboard input for notes
-void Keyboard(GLFWwindow* window, Oscillator& oscillator, std::atomic<bool>& keyPressed);
+void Keyboard(GLFWwindow* window, std::vector<Voice>& voices, std::mutex& voiceMutex,
+              std::atomic<bool>& keyPressed, const std::string& waveform);
 
 // Callback function for handling octave change keys only
 void key_callback(GLFWwindow* window, int key, int scancode, int action, int mods);


### PR DESCRIPTION
## Summary
- allow multiple simultaneous voices via voice container and keyboard handling
- add separate ImGui window for recording, tempo and loop controls
- mix live keyboard with recorded loop for sampler-style playback

## Testing
- `./make.sh` *(fails: imgui.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e4f025864832ca3bbb702db6fce77