### PR TITLE
Fix oscillator move semantics to avoid dangling waveform pointer

### DIFF
--- a/src/Oscillator.cpp
+++ b/src/Oscillator.cpp
@@ -11,7 +11,7 @@
 
 // Oscillator constructor
 Oscillator::Oscillator(unsigned tableSize, double sampleRate)
-    : sampleRate(sampleRate), frequency(0.0), currentPosition(0.0), volume(1.0) 
+    : sampleRate(sampleRate), frequency(0.0), currentPosition(0.0), volume(1.0)
 {
     // Resize wave tables based on input tableSize
     sineWaveTable.resize(tableSize);
@@ -32,6 +32,98 @@ Oscillator::Oscillator(unsigned tableSize, double sampleRate)
 
     activeWaveTable = &sineWaveTable;  // Default wave form is sine
     currentPosition = 0.0;  // Reset current position
+}
+
+// Copy constructor
+Oscillator::Oscillator(const Oscillator& other)
+    : sineWaveTable(other.sineWaveTable),
+      squareWaveTable(other.squareWaveTable),
+      sawtoothWaveTable(other.sawtoothWaveTable),
+      triangleWaveTable(other.triangleWaveTable),
+      noiseWaveTable(other.noiseWaveTable),
+      silentWaveTable(other.silentWaveTable),
+      sampleRate(other.sampleRate),
+      frequency(other.frequency),
+      currentPosition(other.currentPosition),
+      volume(other.volume)
+{
+    copyActiveWaveTable(other);
+}
+
+// Copy assignment
+Oscillator& Oscillator::operator=(const Oscillator& other)
+{
+    if (this != &other) {
+        sineWaveTable   = other.sineWaveTable;
+        squareWaveTable = other.squareWaveTable;
+        sawtoothWaveTable = other.sawtoothWaveTable;
+        triangleWaveTable = other.triangleWaveTable;
+        noiseWaveTable  = other.noiseWaveTable;
+        silentWaveTable = other.silentWaveTable;
+
+        sampleRate = other.sampleRate;
+        frequency = other.frequency;
+        currentPosition = other.currentPosition;
+        volume = other.volume;
+
+        copyActiveWaveTable(other);
+    }
+    return *this;
+}
+
+// Move constructor
+Oscillator::Oscillator(Oscillator&& other) noexcept
+    : sineWaveTable(std::move(other.sineWaveTable)),
+      squareWaveTable(std::move(other.squareWaveTable)),
+      sawtoothWaveTable(std::move(other.sawtoothWaveTable)),
+      triangleWaveTable(std::move(other.triangleWaveTable)),
+      noiseWaveTable(std::move(other.noiseWaveTable)),
+      silentWaveTable(std::move(other.silentWaveTable)),
+      sampleRate(other.sampleRate),
+      frequency(other.frequency),
+      currentPosition(other.currentPosition),
+      volume(other.volume)
+{
+    copyActiveWaveTable(other);
+}
+
+// Move assignment
+Oscillator& Oscillator::operator=(Oscillator&& other) noexcept
+{
+    if (this != &other) {
+        sineWaveTable   = std::move(other.sineWaveTable);
+        squareWaveTable = std::move(other.squareWaveTable);
+        sawtoothWaveTable = std::move(other.sawtoothWaveTable);
+        triangleWaveTable = std::move(other.triangleWaveTable);
+        noiseWaveTable  = std::move(other.noiseWaveTable);
+        silentWaveTable = std::move(other.silentWaveTable);
+
+        sampleRate = other.sampleRate;
+        frequency = other.frequency;
+        currentPosition = other.currentPosition;
+        volume = other.volume;
+
+        copyActiveWaveTable(other);
+    }
+    return *this;
+}
+
+// Helper to map active table pointer after copy/move
+void Oscillator::copyActiveWaveTable(const Oscillator& other)
+{
+    if (other.activeWaveTable == &other.sineWaveTable) {
+        activeWaveTable = &sineWaveTable;
+    } else if (other.activeWaveTable == &other.squareWaveTable) {
+        activeWaveTable = &squareWaveTable;
+    } else if (other.activeWaveTable == &other.sawtoothWaveTable) {
+        activeWaveTable = &sawtoothWaveTable;
+    } else if (other.activeWaveTable == &other.triangleWaveTable) {
+        activeWaveTable = &triangleWaveTable;
+    } else if (other.activeWaveTable == &other.noiseWaveTable) {
+        activeWaveTable = &noiseWaveTable;
+    } else {
+        activeWaveTable = &silentWaveTable;
+    }
 }
 
 // Function to generate a sine waveform

--- a/src/Oscillator.h
+++ b/src/Oscillator.h
@@ -10,6 +10,13 @@ class Oscillator {
 public:
     Oscillator(unsigned tableSize, double sampleRate);
 
+    // Explicitly define copy and move constructors/assignments to ensure
+    // the active waveform pointer always refers to this object's tables
+    Oscillator(const Oscillator& other);
+    Oscillator& operator=(const Oscillator& other);
+    Oscillator(Oscillator&& other) noexcept;
+    Oscillator& operator=(Oscillator&& other) noexcept;
+
     void setWaveform(const std::string& waveform);
     void setFrequency(double frequency);
     void setNote(int note);
@@ -28,6 +35,9 @@ private:
 
     void normalizeAmplitude(std::vector<double>& waveform);
     void applyWindow(std::vector<double>& waveform, const std::vector<double>& window);
+
+    // Helper used by copy/move operations to set the active table pointer
+    void copyActiveWaveTable(const Oscillator& other);
 
     std::vector<double> sineWaveTable;
     std::vector<double> squareWaveTable;


### PR DESCRIPTION
## Summary
- ensure `Oscillator` correctly updates its active wave table when copied or moved
- add helper to map active waveform pointer during copy/move operations

## Testing
- `make.sh` *(fails: fatal error: imgui.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688e51706808832cb1960e2a1b3fcec1