### PR TITLE
Add timeline track visualization with drag snapping

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include <mutex>
 #include <vector>
 #include <string>
+#include <algorithm>
 
 // ImGui includes
 #include <imgui.h>
@@ -30,10 +31,13 @@ struct Instrument {
     bool isRecording;
     bool isPlaying;
     float offsetSeconds; // start position for playback
+    float volume;        // per-track volume
+    bool mute;           // track mute state
 
     Instrument(const std::string& n)
         : name(n), waveform("sine"), playIndex(0),
-          isRecording(false), isPlaying(false), offsetSeconds(0.0f) {}
+          isRecording(false), isPlaying(false), offsetSeconds(0.0f),
+          volume(1.0f), mute(false) {}
 };
 
 // All instruments/tracks
@@ -79,19 +83,21 @@ static int patestCallback( const void *inputBuffer, void *outputBuffer,
                 for (auto &v : inst.voices) {
                     instValue += static_cast<float>(v.osc.getWaveformValue());
                 }
-                value += instValue;
 
-                // Record this instrument if armed
+                // Record raw waveform before applying volume/mute
                 if (inst.isRecording) {
                     inst.recorded.push_back(instValue);
                 }
+
+                float instGain = inst.mute ? 0.0f : inst.volume;
+                value += instValue * instGain;
 
                 // Playback of recorded track
                 if (inst.isPlaying) {
                     size_t offsetSamples = static_cast<size_t>(inst.offsetSeconds * SAMPLE_RATE);
                     size_t idx = inst.playIndex++;
                     if (idx >= offsetSamples && (idx - offsetSamples) < inst.recorded.size()) {
-                        value += inst.recorded[idx - offsetSamples];
+                        value += inst.recorded[idx - offsetSamples] * instGain;
                     }
                     if (idx >= offsetSamples + inst.recorded.size()) {
                         inst.isPlaying = false;
@@ -208,6 +214,11 @@ int main()
             instruments.emplace_back(name);
         }
 
+        float masterVol = volume.load();
+        if (ImGui::SliderFloat("Master Volume", &masterVol, 0.0f, 1.0f)) {
+            volume.store(masterVol);
+        }
+
         std::lock_guard<std::mutex> lock(instrumentsMutex);
         if (!instruments.empty()) {
             std::vector<const char*> names;
@@ -228,6 +239,9 @@ int main()
                 }
             }
 
+            ImGui::SliderFloat("Track Volume", &inst.volume, 0.0f, 1.0f);
+            ImGui::Checkbox("Mute", &inst.mute);
+
             if (!inst.isRecording) {
                 if (ImGui::Button("Record")) {
                     inst.recorded.clear();
@@ -241,9 +255,6 @@ int main()
                     inst.isRecording = false;
                 }
             }
-
-            ImGui::SliderFloat("Start Offset (s)", &inst.offsetSeconds, 0.0f, 10.0f);
-
             if (ImGui::Button("Clear Track")) {
                 inst.recorded.clear();
                 inst.playIndex = 0;
@@ -266,6 +277,72 @@ int main()
                 inst.playIndex = 0;
             }
         }
+
+        ImGui::Separator();
+        ImGui::Text("Timeline");
+        if (!instruments.empty()) {
+            const float trackHeight = 60.0f;
+            float timelineWidth = ImGui::GetContentRegionAvail().x - 10.0f;
+            float maxLength = 10.0f;
+            for (auto &inst : instruments) {
+                float len = inst.offsetSeconds + inst.recorded.size() / static_cast<float>(SAMPLE_RATE);
+                maxLength = std::max(maxLength, len);
+            }
+            float snap = 0.25f; // seconds
+            ImVec2 startPos = ImGui::GetCursorScreenPos();
+            ImDrawList* drawList = ImGui::GetWindowDrawList();
+            float totalHeight = trackHeight * instruments.size();
+
+            int divs = static_cast<int>(maxLength / snap);
+            for (int i = 0; i <= divs; ++i) {
+                float x = startPos.x + (i * timelineWidth) / divs;
+                drawList->AddLine(ImVec2(x, startPos.y), ImVec2(x, startPos.y + totalHeight), IM_COL32(80,80,80,255));
+                if (i % 4 == 0) {
+                    std::string t = std::to_string(i * snap);
+                    drawList->AddText(ImVec2(x + 2, startPos.y - 15), IM_COL32(255,255,255,255), t.c_str());
+                }
+            }
+
+            static int draggedTrack = -1;
+            for (size_t idx = 0; idx < instruments.size(); ++idx) {
+                Instrument &inst = instruments[idx];
+                float y = startPos.y + idx * trackHeight;
+                drawList->AddRectFilled(ImVec2(startPos.x, y), ImVec2(startPos.x + timelineWidth, y + trackHeight), IM_COL32(50,50,50,200));
+                float trackStart = startPos.x + (inst.offsetSeconds / maxLength) * timelineWidth;
+                float trackLenSec = inst.recorded.size() / static_cast<float>(SAMPLE_RATE);
+                float trackWidth = (trackLenSec / maxLength) * timelineWidth;
+                ImVec2 rectMin(trackStart, y + 5);
+                ImVec2 rectMax(trackStart + trackWidth, y + trackHeight - 5);
+                drawList->AddRectFilled(rectMin, rectMax, IM_COL32(100,150,240,255));
+                drawList->AddRect(rectMin, rectMax, IM_COL32(255,255,255,255));
+
+                if (!inst.recorded.empty() && trackWidth > 0) {
+                    float midY = (rectMin.y + rectMax.y) * 0.5f;
+                    for (int x = 0; x < (int)trackWidth; ++x) {
+                        size_t idxSample = static_cast<size_t>((float)x / trackWidth * inst.recorded.size());
+                        float s = inst.recorded[idxSample];
+                        drawList->AddLine(ImVec2(rectMin.x + x, midY),
+                                          ImVec2(rectMin.x + x, midY - s * (trackHeight/2 - 5)),
+                                          IM_COL32(255,255,255,100));
+                    }
+                }
+
+                ImGui::SetCursorScreenPos(rectMin);
+                ImGui::InvisibleButton(("track" + std::to_string(idx)).c_str(), ImVec2(trackWidth, trackHeight - 10));
+                if (ImGui::IsItemActive() && ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
+                    float delta = ImGui::GetIO().MouseDelta.x;
+                    float deltaSeconds = delta / timelineWidth * maxLength;
+                    inst.offsetSeconds = std::max(0.0f, inst.offsetSeconds + deltaSeconds);
+                    draggedTrack = (int)idx;
+                }
+                if (draggedTrack == (int)idx && !ImGui::IsMouseDown(ImGuiMouseButton_Left)) {
+                    inst.offsetSeconds = std::round(inst.offsetSeconds / snap) * snap;
+                    draggedTrack = -1;
+                }
+            }
+            ImGui::Dummy(ImVec2(timelineWidth, totalHeight));
+        }
+
         ImGui::End();
 
         // Rendering


### PR DESCRIPTION
## Summary
- add per-track volume and mute controls
- add master volume slider and track offset drag UI
- visualize recordings on a timeline with grid snapping

## Testing
- `./make.sh` *(fails: imgui.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_688e57c5c448832cab8c09e831e86593